### PR TITLE
Adding channel and message servers

### DIFF
--- a/lib/slack/bot.ex
+++ b/lib/slack/bot.ex
@@ -6,18 +6,18 @@ defmodule Slack.Bot do
   @type t :: %__MODULE__{
           bot_id: String.t(),
           bot_module: module(),
-          team: String.t(),
           team_id: String.t(),
           user_id: String.t()
         }
 
-  @enforce_keys [:bot_id, :bot_module, :team, :team_id, :user_id]
-  defstruct [:bot_id, :bot_module, :team, :team_id, :user_id]
+  @enforce_keys [:bot_id, :bot_module, :team_id, :user_id]
+  defstruct [:bot_id, :bot_module, :team_id, :user_id]
 
   @doc """
   Handle the event from Slack.
+  Return value is ignored.
   """
-  @callback handle_event(type :: String.t(), payload :: map()) :: :ok
+  @callback handle_event(type :: String.t(), payload :: map()) :: any()
 
   defmacro __using__(_opts) do
     quote do
@@ -32,7 +32,6 @@ defmodule Slack.Bot do
     %__MODULE__{
       bot_id: Map.fetch!(params, "bot_id"),
       bot_module: bot_module,
-      team: Map.fetch!(params, "team"),
       team_id: Map.fetch!(params, "team_id"),
       user_id: Map.fetch!(params, "user_id")
     }

--- a/lib/slack/bot.ex
+++ b/lib/slack/bot.ex
@@ -1,18 +1,53 @@
 defmodule Slack.Bot do
   @moduledoc """
-  The slack bot.
+  The Slack Bot.
   """
+
+  @type t :: %__MODULE__{
+          bot_id: String.t(),
+          bot_module: module(),
+          team: String.t(),
+          team_id: String.t(),
+          user_id: String.t()
+        }
+
+  @enforce_keys [:bot_id, :bot_module, :team, :team_id, :user_id]
+  defstruct [:bot_id, :bot_module, :team, :team_id, :user_id]
 
   @doc """
   Handle the event from Slack.
-
-  The return values will be either:
-
-   - `:ok` - No-op, will `ack` immediately.
-   - `{:reply, reply}` - where `reply` can be a `t:map/0` or `t:keyword/0` with these
-    arguments: https://api.slack.com/methods/chat.postMessage#args
-
   """
-  @callback handle_event(type :: String.t(), payload :: map()) ::
-              :ok | {:reply, reply :: keyword() | map()}
+  @callback handle_event(type :: String.t(), payload :: map()) :: :ok
+
+  defmacro __using__(_opts) do
+    quote do
+      import Slack.Bot
+      @behaviour Slack.Bot
+    end
+  end
+
+  # Build a Bot struct from a string-keyed map.
+  @doc false
+  def from_string_params(bot_module, params) do
+    %__MODULE__{
+      bot_id: Map.fetch!(params, "bot_id"),
+      bot_module: bot_module,
+      team: Map.fetch!(params, "team"),
+      team_id: Map.fetch!(params, "team_id"),
+      user_id: Map.fetch!(params, "user_id")
+    }
+  end
+
+  @doc """
+  Send a message to a channel.
+
+  The `message` can be just the message text, or a `t:map/0` of properties that
+  are accepted by Slack's `chat.postMessage` API endpoint.
+  """
+  @spec send_message(String.t(), String.t() | map()) :: Macro.t()
+  defmacro send_message(channel, message) do
+    quote do
+      Slack.MessageServer.send(__MODULE__, unquote(channel), unquote(message))
+    end
+  end
 end

--- a/lib/slack/channel_server.ex
+++ b/lib/slack/channel_server.ex
@@ -1,0 +1,75 @@
+defmodule Slack.ChannelServer do
+  @moduledoc false
+  use GenServer
+
+  require Logger
+
+  # This is fairly arbitrary, but we'll hibernate this process after 5 minutes
+  # of waiting for any incoming messages.
+  @hibernate_ms :timer.minutes(5)
+
+  # ----------------------------------------------------------------------------
+  # Public API
+  # ----------------------------------------------------------------------------
+
+  def start_link({token, bot}) do
+    Logger.info("[ChannelServer] starting for #{bot.bot_module}...")
+
+    GenServer.start_link(__MODULE__, {token, bot},
+      hibernate_after: @hibernate_ms,
+      name: via_tuple(bot)
+    )
+  end
+
+  def join(bot, channel) do
+    GenServer.cast(via_tuple(bot), {:join, channel})
+  end
+
+  def part(bot, channel) do
+    GenServer.cast(via_tuple(bot), {:part, channel})
+  end
+
+  # ----------------------------------------------------------------------------
+  # GenServer Callbacks
+  # ----------------------------------------------------------------------------
+
+  @impl true
+  def init({token, bot}) do
+    state = %{
+      bot: bot,
+      channels: fetch_channels(token),
+      token: token
+    }
+
+    {:ok, state, {:continue, :join}}
+  end
+
+  @impl true
+  def handle_continue(:join, state) do
+    Enum.each(state.channels, &join(state.bot, &1))
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:join, channel}, state) do
+    Logger.info("[ChannelServer] #{state.bot.bot_module} joining #{channel}...")
+    {:ok, _} = Slack.MessageServer.start_supervised(state.token, state.bot, channel)
+    {:noreply, Map.update!(state, :channels, &[channel | &1])}
+  end
+
+  def handle_cast({:part, channel}, state) do
+    Logger.info("[ChannelServer] #{state.bot.bot_module} leaving #{channel}...")
+    :ok = Slack.MessageServer.stop(state.bot, channel)
+    {:noreply, Map.update!(state, :channels, &List.delete(&1, channel))}
+  end
+
+  defp via_tuple(%Slack.Bot{bot_module: bot}) do
+    {:via, Registry, {Slack.ChannelServerRegistry, bot}}
+  end
+
+  defp fetch_channels(token) do
+    "users.conversations"
+    |> Slack.API.stream(token, "channels")
+    |> Enum.map(& &1["id"])
+  end
+end

--- a/lib/slack/message_server.ex
+++ b/lib/slack/message_server.ex
@@ -1,0 +1,130 @@
+defmodule Slack.MessageServer do
+  @moduledoc false
+  use GenServer
+
+  require Logger
+
+  # This is fairly arbitrary, but we'll hibernate this process after 5 minutes
+  # of waiting for any incoming messages.
+  @hibernate_ms :timer.minutes(5)
+
+  # Slack has a rate-limit of 1 message per second per channel.
+  @message_rate_ms :timer.seconds(1)
+
+  # ----------------------------------------------------------------------------
+  # Public API
+  # ----------------------------------------------------------------------------
+
+  def start_link({token, bot, channel}) do
+    Logger.info("[MessageServer] starting for #{bot.bot_module} in #{channel}...")
+
+    GenServer.start_link(__MODULE__, {token, bot, channel},
+      hibernate_after: @hibernate_ms,
+      name: via_tuple(bot, channel)
+    )
+  end
+
+  def start_supervised(token, bot, channel) do
+    DynamicSupervisor.start_child(
+      Slack.DynamicSupervisor,
+      {Slack.MessageServer, {token, bot, channel}}
+    )
+  end
+
+  def send(bot, channel, message) when is_binary(channel) do
+    GenServer.cast(via_tuple(bot, channel), {:add, message})
+  end
+
+  def stop(bot, channel) do
+    GenServer.stop(via_tuple(bot, channel))
+  end
+
+  # ----------------------------------------------------------------------------
+  # GenServer Callbacks
+  # ----------------------------------------------------------------------------
+
+  @impl true
+  def init({token, bot, channel}) do
+    state = %{
+      bot: bot,
+      channel: channel,
+      queue: :queue.new(),
+      timer_ref: schedule_next(),
+      token: token
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  # If we are paused, we will add it to the queue and start scheduling messages.
+  def handle_cast({:add, message}, %{timer_ref: nil} = state) do
+    Logger.debug("[MessageServer] Adding message #{inspect(message)}")
+    state = send_and_schedule_next(%{state | queue: :queue.in(message, state.queue)})
+    {:noreply, state}
+  end
+
+  # It is not paused, so that means we are still scheduling messages, so we will
+  # just add the message to queue.
+  def handle_cast({:add, message}, state) do
+    Logger.debug("[MessageServer] Adding message #{inspect(message)}")
+    state = %{state | queue: :queue.in(message, state.queue)}
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:send, state) do
+    {:noreply, send_and_schedule_next(state)}
+  end
+
+  # ----------------------------------------------------------------------------
+  # Private API
+  # ----------------------------------------------------------------------------
+
+  defp send_and_schedule_next(state) do
+    case :queue.out(state.queue) do
+      {:empty, _} ->
+        Logger.debug("[MessageServer] [#{state.channel}] no more messages to send: PAUSED")
+        %{state | timer_ref: nil}
+
+      {{:value, message}, rest} ->
+        Logger.debug("[MessageServer] Sending next message: #{inspect(message)}")
+        send_message(state.token, state.channel, message)
+        %{state | queue: rest, timer_ref: schedule_next()}
+    end
+  end
+
+  # Users can send a message either as string, or as a keyword/map of args.
+  # When they send it as a string, we'll put it into a map, with the `:text`
+  # key. The args are assumed to be any arg that is accepted by Slack's
+  # `chat.postMessage` API endpoint.
+  defp send_message(token, channel, message) when is_binary(message) do
+    send_message(token, %{channel: channel, text: message})
+  end
+
+  defp send_message(token, channel, message) do
+    send_message(token, Enum.into(message, %{channel: channel}, message))
+  end
+
+  defp send_message(token, %{} = args) do
+    case Slack.API.post("chat.postMessage", token, args) do
+      {:ok, _} ->
+        Logger.debug("[MessageServer] SENT: #{inspect(args)}")
+
+      {:error, error} ->
+        Logger.error("[MessageServer] error sending message #{inspect(error)}")
+    end
+  end
+
+  defp schedule_next(after_ms \\ @message_rate_ms) do
+    Process.send_after(self(), :send, after_ms)
+  end
+
+  defp via_tuple(%Slack.Bot{bot_module: bot}, channel) do
+    via_tuple(bot, channel)
+  end
+
+  defp via_tuple(bot, channel) do
+    {:via, Registry, {Slack.MessageServerRegistry, {bot, channel}}}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,9 @@ defmodule Slack.MixProject do
   def project do
     [
       app: :slack_elixir,
-      version: "0.1.1",
+      version: "1.0.0-rc.1",
       elixir: "~> 1.14",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: [plt_file: {:no_warn, "priv/plts/project.plt"}],
@@ -22,6 +23,10 @@ defmodule Slack.MixProject do
       extra_applications: [:logger]
     ]
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/test/slack/bot_test.exs
+++ b/test/slack/bot_test.exs
@@ -1,0 +1,39 @@
+defmodule Slack.BotTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Slack.TestBot
+
+  setup do
+    stub(Slack.MessageServer)
+    :ok
+  end
+
+  defp message_event(text) do
+    %{
+      "type" => "message",
+      "channel" => "channel-foo",
+      "text" => text
+    }
+  end
+
+  test "handles messages" do
+    Slack.MessageServer
+    |> expect(:send, 1, fn TestBot, "channel-foo", message ->
+      assert message == "hello back!"
+      :ok
+    end)
+
+    TestBot.handle_event("message", message_event("hello there."))
+    TestBot.handle_event("message", message_event("No way, José!"))
+  end
+
+  test "fallbacks" do
+    Slack.MessageServer
+    |> stub(:send, fn _, _, _ ->
+      raise "failed test"
+    end)
+
+    assert :noop = TestBot.handle_event("foo", message_event("No way, José!"))
+  end
+end

--- a/test/slack/socket_test.exs
+++ b/test/slack/socket_test.exs
@@ -2,19 +2,7 @@ defmodule Slack.SocketTest do
   use ExUnit.Case, async: false
   use Mimic
 
-  @message_event """
-  {
-    "envelope_id": "eid-123",
-    "type": "message",
-    "payload": {
-      "event": {
-        "type": "message",
-        "channel": "channel-foo",
-        "text": "hello"
-      }
-    }
-  }
-  """
+  alias Slack.TestBot
 
   @foo_event """
   {
@@ -29,68 +17,30 @@ defmodule Slack.SocketTest do
   }
   """
 
-  defmodule Bot do
-    use Slack.Bot
-
-    @impl true
-    def handle_event("message", _payload) do
-      send_message("channel-foo", "hello world")
-      :ok
-    end
-
-    def handle_event(_type, _payload) do
-      :ok
-    end
-  end
+  @bot %Slack.Bot{
+    bot_id: "bot-123-ABC",
+    bot_module: TestBot,
+    team_id: "team-123-ABC",
+    user_id: "user-123-ABC"
+  }
 
   setup :set_mimic_global
 
   setup do
-    # Slack.API
-    # |> stub()
-    # |> expect(:post, 1, fn "apps.connections.open", "a" ->
-    #   {:ok, %{"url" => "wss://foo"}}
-    # end)
-
-    # WebSockex
-    # |> stub()
-    # |> expect(:start_link, 1, fn "wss://foo", _, _ ->
-    #   {:ok, make_ref()}
-    # end)
-
-    # {:ok, pid} = start_supervised({Slack.Supervisor, app_token: "a", bot_token: "t", bot: Bot})
+    stub(Slack.API)
     start_supervised!({Registry, keys: :unique, name: Slack.MessageServerRegistry})
-    pid = start_supervised!({Slack.MessageServer, {Bot, "t", "channel-foo"}})
 
-    {:ok, message_server: pid}
-  end
+    start_supervised!(
+      {PartitionSupervisor, child_spec: Task.Supervisor, name: Slack.TaskSupervisors}
+    )
 
-  test "bot can reply", %{message_server: pid} do
-    Slack.API
-    |> stub()
-    |> expect(:post, 1, fn "chat.postMessage", "t", args ->
-      assert Access.get(args, :channel) == "channel-foo"
-      assert Access.get(args, :text) == "hello world"
-      {:ok, %Req.Response{status: 200, body: %{"ok" => true}}}
-    end)
-
-    # state = %{bot_token: "t", bot: Bot}
-
-    # Slack.ChannelServer.join("channel-foo")
-
-    # [{:undefined, pid}] = DynamicSupervisor.which_children(Slack.DynamicSupervisor)
-    ref = Process.monitor(pid)
-
-    %{"payload" => %{"event" => event}} = Jason.decode!(@message_event)
-
-    assert :ok = Bot.handle_event(event["type"], event)
-    assert_receive {:DOWN, ^ref, _, _, _}, 1200
+    :ok
   end
 
   test "bot can noop" do
     stub(Slack.API)
 
-    state = %{bot: Bot}
+    state = %{bot: @bot}
 
     assert {:reply, ack_frame, _state} = Slack.Socket.handle_frame({:text, @foo_event}, state)
     assert {:text, ~S({"envelope_id":"eid-234"})} = ack_frame

--- a/test/slack/socket_test.exs
+++ b/test/slack/socket_test.exs
@@ -1,5 +1,5 @@
 defmodule Slack.SocketTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   use Mimic
 
   @message_event """
@@ -30,11 +30,12 @@ defmodule Slack.SocketTest do
   """
 
   defmodule Bot do
-    @behaviour Slack.Bot
+    use Slack.Bot
 
     @impl true
     def handle_event("message", _payload) do
-      {:reply, channel: "channel-foo", text: "hello world"}
+      send_message("channel-foo", "hello world")
+      :ok
     end
 
     def handle_event(_type, _payload) do
@@ -42,19 +43,48 @@ defmodule Slack.SocketTest do
     end
   end
 
-  test "bot can reply" do
+  setup :set_mimic_global
+
+  setup do
+    # Slack.API
+    # |> stub()
+    # |> expect(:post, 1, fn "apps.connections.open", "a" ->
+    #   {:ok, %{"url" => "wss://foo"}}
+    # end)
+
+    # WebSockex
+    # |> stub()
+    # |> expect(:start_link, 1, fn "wss://foo", _, _ ->
+    #   {:ok, make_ref()}
+    # end)
+
+    # {:ok, pid} = start_supervised({Slack.Supervisor, app_token: "a", bot_token: "t", bot: Bot})
+    start_supervised!({Registry, keys: :unique, name: Slack.MessageServerRegistry})
+    pid = start_supervised!({Slack.MessageServer, {Bot, "t", "channel-foo"}})
+
+    {:ok, message_server: pid}
+  end
+
+  test "bot can reply", %{message_server: pid} do
     Slack.API
     |> stub()
     |> expect(:post, 1, fn "chat.postMessage", "t", args ->
-      assert args[:channel] == "channel-foo"
-      assert args[:text] == "hello world"
+      assert Access.get(args, :channel) == "channel-foo"
+      assert Access.get(args, :text) == "hello world"
       {:ok, %Req.Response{status: 200, body: %{"ok" => true}}}
     end)
 
-    state = %{bot_token: "t", bot: Bot}
+    # state = %{bot_token: "t", bot: Bot}
 
-    assert {:reply, ack_frame, _state} = Slack.Socket.handle_frame({:text, @message_event}, state)
-    assert {:text, ~S({"envelope_id":"eid-123"})} = ack_frame
+    # Slack.ChannelServer.join("channel-foo")
+
+    # [{:undefined, pid}] = DynamicSupervisor.which_children(Slack.DynamicSupervisor)
+    ref = Process.monitor(pid)
+
+    %{"payload" => %{"event" => event}} = Jason.decode!(@message_event)
+
+    assert :ok = Bot.handle_event(event["type"], event)
+    assert_receive {:DOWN, ^ref, _, _, _}, 1200
   end
 
   test "bot can noop" do

--- a/test/support/test_bot.ex
+++ b/test/support/test_bot.ex
@@ -1,0 +1,15 @@
+defmodule Slack.TestBot do
+  @moduledoc """
+  Test bot implementation.
+  """
+  use Slack.Bot
+
+  @impl Slack.Bot
+  def handle_event("message", %{"text" => text}) do
+    if String.contains?(text, "hello") do
+      send_message("channel-foo", "hello back!")
+    end
+  end
+
+  def handle_event(_type, _payload), do: :noop
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
 Mimic.copy(Slack.API)
+Mimic.copy(Slack.MessageServer)
 Mimic.copy(WebSockex)
 ExUnit.start()


### PR DESCRIPTION
A dynamically supervised message server per channel, for queueing messages for sending and self-rate-limiting them to 1 message per second per channel, which is what Slack will rate-limit their `postMessage` API to.

(They do allow some burst posting, but there are no guarantees around message deliveries and I think some could be lost, so this is better, in my opinion)