### PR TITLE
updating req

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Slack.MixProject do
     [
       # Direct dependencies.
       {:jason, "~> 1.4"},
-      {:req, "~> 0.3.0"},
+      {:req, "~> 0.3"},
       {:websockex, "~> 0.4.3"},
 
       # Dev/test dependencies.


### PR DESCRIPTION
Just updating the req dependency because Phoenix use swoosh by default and relay on `req ~> 0.4`  so this version is preventing me to use it.